### PR TITLE
fix test_writer

### DIFF
--- a/codec/package.json
+++ b/codec/package.json
@@ -1,0 +1,8 @@
+{
+  "dependencies": {},
+  "devDependencies": {
+    "packet-stream-codec": "^1.1.0",
+    "pull-stream": "^3.2.3",
+    "stream-to-pull-stream": "^1.6.6"
+  }
+}

--- a/codec/test_writer.js
+++ b/codec/test_writer.js
@@ -1,5 +1,6 @@
 var pull = require('pull-stream')
 var psc = require('packet-stream-codec')
+var toPull = require('stream-to-pull-stream')
 // var split = require('pull-randomly-split')
 
 function flat (err) {
@@ -24,13 +25,7 @@ var examples = [
 pull(
   pull.values(examples),
   psc.encode(),
-  // split(),
-  pull.collect(function (err, array) {
-    if (err) throw err
-    var n = array.length
-    for (var i = 0; i < n; i++) {
-      // console.dir(array[i].toString())
-      process.stdout.write(array[i].toString())
-    }
-  })
+  toPull.sink(process.stdout)
 )
+
+


### PR DESCRIPTION
Hey,

Firstly, I must apologise for not dealing with this sooner. For some reason I thought this was gonna be a more difficult problem, but i'm pretty sure that it was just converting the buffer to a string before writing it out. Better pull stream documentation would likely have avoided this.

Converting the buffer to a string was a problem because by default it converts it to a utf8 string, and since psc uses length delimiters, and things like that, node sometimes has no way to represent a buffer as a given utf8 string that is also reverseable. a buffer could contain half a multibyte utf8 character, so stringifying two buffers then concatenating them as strings might have a different result to concatenating them as buffers then converting to a string. the right thing to do is write it as a buffer.

I think your remark about the ordering threw me off - but when i look at your output, `goodbye` _is_ after `hello`. So I think it's okay?

I tried to run your code... I got to here:

```
2016/03/24 16:20:27 dbg: (9 bytes)
2016/03/24 16:20:27 
00000000  02 00 00 00 17 00 00 00  00                       |.........|
2016/03/24 16:20:27 dbg: (23 bytes)
2016/03/24 16:20:27 
00000000  5b 22 65 76 65 6e 74 22  2c 7b 22 6f 6b 61 79 22  |["event",{"okay"|
00000010  3a 74 72 75 65 7d 5d                              |:true}]|
2016/03/24 16:20:27 dbg: (9 bytes)
2016/03/24 16:20:27 
00000000  01 00 00 00 08 00 00 00  01                       |.........|
2016/03/24 16:20:27 dbg: (8 bytes)
2016/03/24 16:20:27 
00000000  77 68 61 74 65 76 65 72                           |whatever|
2016/03/24 16:20:27 dbg: (9 bytes)
2016/03/24 16:20:27 
00000000  08 00 00 00 05 00 00 00  02                       |.........|
2016/03/24 16:20:27 dbg: (5 bytes)
2016/03/24 16:20:27 
00000000  68 65 6c 6c 6f                                    |hello|
2016/03/24 16:20:27 dbg: (9 bytes)
2016/03/24 16:20:27 
00000000  08 00 00 00 07 ff ff ff  fe                       |.........|
2016/03/24 16:20:27 dbg: (7 bytes)
2016/03/24 16:20:27 
00000000  67 6f 6f 64 62 79 65                              |goodbye|
2016/03/24 16:20:27 dbg: (9 bytes)
2016/03/24 16:20:27 
00000000  06 00 00 01 be ff ff ff  fd                       |.........|
2016/03/24 16:20:27 dbg: (446 bytes)
2016/03/24 16:20:27 
00000000  7b 22 6d 65 73 73 61 67  65 22 3a 22 69 6e 74 65  |{"message":"inte|
00000010  6e 74 69 6f 6e 61 6c 22  2c 22 6e 61 6d 65 22 3a  |ntional","name":|
00000020  22 45 72 72 6f 72 22 2c  22 73 74 61 63 6b 22 3a  |"Error","stack":|
00000030  22 45 72 72 6f 72 3a 20  69 6e 74 65 6e 74 69 6f  |"Error: intentio|
00000040  6e 61 6c 5c 6e 20 20 20  20 61 74 20 4f 62 6a 65  |nal\n    at Obje|
00000050  63 74 2e 3c 61 6e 6f 6e  79 6d 6f 75 73 3e 20 28  |ct.<anonymous> (|
00000060  2f 68 6f 6d 65 2f 64 6f  6d 69 6e 69 63 2f 63 2f  |/home/dominic/c/|
00000070  67 6f 2d 6d 75 78 72 70  63 2f 63 6f 64 65 63 2f  |go-muxrpc/codec/|
00000080  74 65 73 74 5f 77 72 69  74 65 72 2e 6a 73 3a 32  |test_writer.js:2|
00000090  30 3a 35 31 29 5c 6e 20  20 20 20 61 74 20 4d 6f  |0:51)\n    at Mo|
000000a0  64 75 6c 65 2e 5f 63 6f  6d 70 69 6c 65 20 28 6d  |dule._compile (m|
000000b0  6f 64 75 6c 65 2e 6a 73  3a 34 31 33 3a 33 34 29  |odule.js:413:34)|
000000c0  5c 6e 20 20 20 20 61 74  20 4f 62 6a 65 63 74 2e  |\n    at Object.|
000000d0  4d 6f 64 75 6c 65 2e 5f  65 78 74 65 6e 73 69 6f  |Module._extensio|
000000e0  6e 73 2e 2e 6a 73 20 28  6d 6f 64 75 6c 65 2e 6a  |ns..js (module.j|
000000f0  73 3a 34 32 32 3a 31 30  29 5c 6e 20 20 20 20 61  |s:422:10)\n    a|
00000100  74 20 4d 6f 64 75 6c 65  2e 6c 6f 61 64 20 28 6d  |t Module.load (m|
00000110  6f 64 75 6c 65 2e 6a 73  3a 33 35 37 3a 33 32 29  |odule.js:357:32)|
00000120  5c 6e 20 20 20 20 61 74  20 46 75 6e 63 74 69 6f  |\n    at Functio|
00000130  6e 2e 4d 6f 64 75 6c 65  2e 5f 6c 6f 61 64 20 28  |n.Module._load (|
00000140  6d 6f 64 75 6c 65 2e 6a  73 3a 33 31 34 3a 31 32  |module.js:314:12|
00000150  29 5c 6e 20 20 20 20 61  74 20 46 75 6e 63 74 69  |)\n    at Functi|
00000160  6f 6e 2e 4d 6f 64 75 6c  65 2e 72 75 6e 4d 61 69  |on.Module.runMai|
00000170  6e 20 28 6d 6f 64 75 6c  65 2e 6a 73 3a 34 34 37  |n (module.js:447|
00000180  3a 31 30 29 5c 6e 20 20  20 20 61 74 20 73 74 61  |:10)\n    at sta|
00000190  72 74 75 70 20 28 6e 6f  64 65 2e 6a 73 3a 31 34  |rtup (node.js:14|
000001a0  30 3a 31 38 29 5c 6e 20  20 20 20 61 74 20 6e 6f  |0:18)\n    at no|
000001b0  64 65 2e 6a 73 3a 31 30  30 31 3a 33 22 7d        |de.js:1001:3"}|
2016/03/24 16:20:27 dbg: (9 bytes)
2016/03/24 16:20:27 
00000000  0e 00 00 00 04 00 00 00  02                       |.........|
2016/03/24 16:20:27 dbg: (4 bytes)
2016/03/24 16:20:27 
00000000  74 72 75 65                                       |true|
2016/03/24 16:20:27 dbg: (9 bytes)
2016/03/24 16:20:27 
00000000  0e 00 00 00 04 ff ff ff  fe                       |.........|
2016/03/24 16:20:27 dbg: (4 bytes)
2016/03/24 16:20:27 
00000000  74 72 75 65                                       |true|
2016/03/24 16:20:27 dbg: (9 bytes)
2016/03/24 16:20:27 
00000000  00 00 00 00 00 00 00 00  00                       |.........|
2016/03/24 16:20:27 dbg: (0 bytes) Error: EOF
2016/03/24 16:20:27 
--- FAIL: TestReader (0.17s)
	reader_test.go:31: Stream(false) EndErr(false) Type(JSON) Len(23) Req(0)
		(n:23) "[\"event\",{\"okay\":true}]"
	reader_test.go:31: Stream(false) EndErr(false) Type(String) Len(8) Req(1)
		(n:8) "whatever"
	reader_test.go:31: Stream(true) EndErr(false) Type(Buffer) Len(5) Req(2)
		(n:5) "hello"
	reader_test.go:31: Stream(true) EndErr(false) Type(Buffer) Len(7) Req(-2)
		(n:7) "goodbye"
	reader_test.go:31: Stream(false) EndErr(true) Type(JSON) Len(446) Req(-3)
		(n:446) "{\"message\":\"intentional\",\"name\":\"Error\",\"stack\":\"E"...
	reader_test.go:31: Stream(true) EndErr(true) Type(JSON) Len(4) Req(2)
		(n:4) "true"
	reader_test.go:31: Stream(true) EndErr(true) Type(JSON) Len(4) Req(-2)
		(n:4) "true"
	reader_test.go:31: Stream(false) EndErr(false) Type(Buffer) Len(0) Req(0)
		(n:0) ""
	reader_test.go:28: pkt-codec: header read failed: EOF
FAIL
FAIL	command-line-arguments	0.178s

```

it looks like it did get to the end of the file though, and that the last line was 9 zeros?